### PR TITLE
[DRAFT] Allow columns to be disabled by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ Inertia::render('Page/Index')->table(function ($table) {
 
 #### Columns
 
-With the `addColumn` method, you can specify which columns you want to be toggleable. You need to pass in a key and label for each column. With the `addColumns` method, you can add multiple columns at once.
+With the `addColumn` method, you can specify which columns you want to be toggleable. You need to pass in a key and label for each column. Of course, you may not want all columns to shown initially. In this case you can pass an optional third parameter - boolean `false` if you want the column to start off hidden. With the `addColumns` method, you can add multiple columns at once, and they will default to being shown.
 
 ```php
 Inertia::render('Page/Index')->table(function ($table) {
     $table->addColumn('name', 'Name');
+    $table->addColumn('hidden_column', 'Hidden Column', false);
 
     $table->addColumns([
         'email' => 'Email',
@@ -153,7 +154,7 @@ class UserIndexController
             ])->addColumns([
                 'email' => 'Email address',
                 'language_code' => 'Language',
-            ]);
+            ])->addColumn('hidden_column', 'Hidden Column', false);
         });
     }
 }
@@ -191,6 +192,7 @@ You can use the named `#head` slot to provide the table header and the named `#b
         <th @click.prevent="sortBy('name')">Name</th>
         <th v-show="showColumn('email')" @click.prevent="sortBy('email')">Email</th>
         <th v-show="showColumn('language_code')" @click.prevent="sortBy('language_code')">Language</th>
+        <th v-show="showColumn('hidden_column')">Hidden Column</th>
       </tr>
     </template>
 
@@ -199,6 +201,7 @@ You can use the named `#head` slot to provide the table header and the named `#b
         <td>{{ user.name }}</td>
         <td v-show="showColumn('email')">{{ user.email }}</td>
         <td v-show="showColumn('language_code')">{{ user.language_code }}</td>
+        <td v-show="showColumn('hidden_column')">{{ user.hidden_column }}</td>
       </tr>
     </template>
   </Table>

--- a/php/InertiaTable.php
+++ b/php/InertiaTable.php
@@ -163,12 +163,12 @@ class InertiaTable
      * @param string $label
      * @return self
      */
-    public function addColumn(string $key, string $label): self
+    public function addColumn(string $key, string $label, bool $enabled = true): self
     {
         $this->columns->put($key, [
             'key'     => $key,
             'label'   => $label,
-            'enabled' => true,
+            'enabled' => $enabled,
         ]);
 
         return $this;


### PR DESCRIPTION
This PR updates the `addColumn()` method to allow the third parameter in the column object- whether it is enabled or not. Currently this is always set to true, but in some cases you may wish to have some columns set to false. This means they will be toggleable, but will initially be toggled off, or hidden.

I thought it was reasonable to only do this on the `addColumn()` method and not also on `addColumns()`.