### PR TITLE
Ability to make a column optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Inertia::render('Page/Index')->table(function ($table) {
 });
 ```
 
+The `addColumn` method has an optional third parameter to disable the column by default:
+
+```php
+$table->addColumn('name', 'Name', false);
+```
+
 #### Disable global search
 
 By default, global search is enabled. This query will be applied to the filters by the `global` attribute. If you don't want to use the global search, you can use the `disableGlobalSearch` method.

--- a/php/InertiaTable.php
+++ b/php/InertiaTable.php
@@ -161,14 +161,15 @@ class InertiaTable
      *
      * @param string $key
      * @param string $label
+     * @param bool $enabled
      * @return self
      */
-    public function addColumn(string $key, string $label): self
+    public function addColumn(string $key, string $label, bool $enabled = true): self
     {
         $this->columns->put($key, [
             'key'     => $key,
             'label'   => $label,
-            'enabled' => true,
+            'enabled' => $enabled,
         ]);
 
         return $this;
@@ -177,7 +178,7 @@ class InertiaTable
     public function addColumns(array $columns = []): self
     {
         foreach ($columns as $key => $value) {
-            $this->addColumn($key, $value);
+            $this->addColumn($key, $value, true);
         }
 
         return $this;

--- a/tests/InertiaTableTest.php
+++ b/tests/InertiaTableTest.php
@@ -48,6 +48,25 @@ class InertiaTableTest extends TestCase
     }
 
     /** @test */
+    public function it_can_add_a_column_that_is_disabled_by_default()
+    {
+        $table = new InertiaTable($this->request());
+        $table->addColumn('name', 'Name', false);
+
+        $props = $table->getQueryBuilderProps();
+
+        Assert::assertArraySubset([
+            "columns" => [
+                "name" => [
+                    "key"     => "name",
+                    "label"   => "Name",
+                    "enabled" => false,
+                ],
+            ],
+        ], $props);
+    }
+
+    /** @test */
     public function it_gets_the_default_toggled_columns_from_the_query_String()
     {
         $table = new InertiaTable($this->request(function (Request $request) {


### PR DESCRIPTION
This small change will allow:
* make a column "optional" on the front end, so we can show a simpler report first, and advanced user can toggle additional column
* also allows us to implement persistence of user columns selection on the server

The option already exists but is not accessible in the column builder.