### PR TITLE
Added missing translations for "Reset" and "Search" terms

### DIFF
--- a/js/Components/TableGlobalSearch.vue
+++ b/js/Components/TableGlobalSearch.vue
@@ -27,10 +27,14 @@
 </template>
 
 <script setup>
+  import { getTranslations } from "../translations.js";
+
+const translations = getTranslations();
+
 defineProps({
     label: {
         type: String,
-        default: "Search...",
+        default: translations.search,
         required: false,
     },
 

--- a/js/Components/TableReset.vue
+++ b/js/Components/TableReset.vue
@@ -19,11 +19,16 @@
         clip-rule="evenodd"
       />
     </svg>
-    <span>Reset</span>
+    <span>{{ translations.reset }}</span>
   </button>
 </template>
 
 <script setup>
+
+import { getTranslations } from "../translations.js";
+
+const translations = getTranslations();
+
 defineProps({
     onClick: {
         type: Function,

--- a/js/translations.js
+++ b/js/translations.js
@@ -6,7 +6,9 @@ const translationsObject = {
         per_page: "per page",
         previous: "Previous",
         results: "results",
-        to: "to"
+        to: "to",
+        reset: "Reset",
+        search: "Search..."
     }
 };
 


### PR DESCRIPTION
Hi
This is a pull request so the terms "Search" (placeholder in the global search field) and "Reset" (text of the Reset button) are  set in the translation settings.

This avoids to use custom components in slots to just translate the texts ;)